### PR TITLE
Turn off previous note when stop playing

### DIFF
--- a/examples/E03_MIDI/E03_MIDI.ino
+++ b/examples/E03_MIDI/E03_MIDI.ino
@@ -90,7 +90,7 @@ void loop(){
       }
     }else{
       if (playing){
-         MIDI.sendNoteOff(OpenPipe.note,0,1);   // Stop the note
+         MIDI.sendNoteOff(previous_note,0,1);   // Stop the note
          playing = false;
        }
     }


### PR DESCRIPTION
I've noticed occasional stuck notes using this example. This change seems to fix the problem. The problem, I suspect, happens when the *on* thumb is released at the same time as there are other fingering changes, in which case this sketch would turn off the note corresponding to the new fingering instead of turning off the note that was previously turned on, resulting in a stuck note.